### PR TITLE
Adds VS Code and github CLI installation instructions

### DIFF
--- a/_includes/install_instructions/editor-vscode.html
+++ b/_includes/install_instructions/editor-vscode.html
@@ -1,0 +1,16 @@
+<div id="editor-vs-code">
+  <h3>VS Code</h3>
+
+  <p>
+    When you're writing code, it's nice to have a text editor that is
+    optimized for writing code, with features like automatic
+    color-coding of key words. A very popular and powerful text editor
+    for code is <a href="https://code.visualstudio.com/">Visual Studio Code</a>.
+  </p>
+
+  <p>
+    <a href="https://code.visualstudio.com/download"> Download VS
+    Code</a> for your operating system following the default
+    indications of the installer.
+  </p>
+</div>

--- a/_includes/install_instructions/github.html
+++ b/_includes/install_instructions/github.html
@@ -1,0 +1,51 @@
+{% comment %}
+GitHub CLI  Setup instructions rely on Shell instructions. If you don't include
+Shell instructions as part of your workshop website, make sure to adjust
+the text below accordingly.
+{% endcomment %}
+<div id="github">
+  <h3>GitHub CLI</h3>
+  <p>
+    GitHub provides a command line interface (CLI) that we will use to simplify the authentication setup between our computer and GitHub's platform.
+  </p>
+
+  <div>
+    <ul class="nav nav-tabs" role="tablist">
+      <li role="presentation" class="active"><a data-os="windows" href="#github-windows" aria-controls="Windows" role="tab" data-toggle="tab">Windows</a></li>
+      <li role="presentation"><a data-os="macos" href="#github-macos" aria-controls="MacOS" role="tab" data-toggle="tab">MacOS</a></li>
+      <li role="presentation"><a data-os="linux" href="#github-linux" aria-controls="Linux" role="tab" data-toggle="tab">Linux/WSL</a></li>
+    </ul>
+
+    <div class="tab-content">
+        <article role="tabpanel" class="tab-pane active" id="github-windows">
+            <p>
+                Proceed to install <a href="https://cli.github.com/">Github CLI</a> by downloading the installer.
+            </p>
+        </article>
+        <article role="tabpanel" class="tab-pane" id="github-macos">
+            <p>
+                The easiest way to install <a href="https://cli.github.com/">Github CLI</a> is through <a href="https://brew.sh/">homebrew</a>. First you need to install homebrew:
+                <ol>
+                    <li>Open a terminal window</li>
+                    <li><p> Type </p>
+                        <div class="org-src-container">
+                            <pre class="src src-bash">/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"</pre>
+                        </div>
+                        <p> Follow the installation prompts </p>
+                    </li>
+                    <li><p> Once homebrew is installed, you can then install Github's CLI</p>
+                        <div class="org-src-container">
+                            <pre class="src src-bash">brew install gh</pre>
+                        </div>
+                    </li>
+                </ol>
+            </p>
+      </article>
+      <article role="tabpanel" class="tab-pane" id="github-linux">
+          <p>
+              Proceed to install <a href="https://github.com/cli/cli#linux--bsd">Github's CLI</a> following the option according to your distribution.
+          </p>
+      </article>
+    </div>
+  </div>
+</div>

--- a/_includes/swc/setup.html
+++ b/_includes/swc/setup.html
@@ -15,7 +15,9 @@
 </div>
 
 {% include install_instructions/git.html %}
+{% include install_instructions/github.html %}
 {% include install_instructions/editor.html %}
+{% include install_instructions/editor-vscode.html %}
 
 {% if site.flavor == "r" %}
 {% include install_instructions/r.html %}


### PR DESCRIPTION
As previously discussed, we will use gh cli to set up ssh keys with github and vs code to show how to work with a git repository for things other than R.